### PR TITLE
recognition accuracy finalized and train while recognizing mode added

### DIFF
--- a/src/Components/SpeechProcessing.js
+++ b/src/Components/SpeechProcessing.js
@@ -123,7 +123,9 @@ class SpeechProcessing extends Component {
         let result = Recognize.recognize(internalLeftChannel, this.setStateMsgFunc);
         if (result) {
           this.setState({
-            msg: "Great! the result is ===> "+result.transcript+" <=== try more."
+            msg: <>"Great! the result is {'===>'} {result.transcript} {'<==='} try more."<br/>
+            <button onClick={() => Recognize.saveRecognizedFeature()}>Add feature to dataset</button>
+            </>
           });
           console.log(result.transcript);
           console.log(this.props);

--- a/src/Constants/MfccCounterHist1.js
+++ b/src/Constants/MfccCounterHist1.js
@@ -1,1 +1,33 @@
-export const training1Cnter = [null,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5]
+
+export class trainingCnter1 {
+    static mfccHistoryCunters = [];
+    static getMfccHistoryCunters = () => {
+        this.mfccHistoryCunters[0] = null;
+        this.mfccHistoryCunters['N'] = 5;
+        this.mfccHistoryCunters['R'] = 5;
+        this.mfccHistoryCunters['B'] = 5;
+        this.mfccHistoryCunters['K'] = 5;
+        this.mfccHistoryCunters['Q'] = 5;
+        this.mfccHistoryCunters['a'] = 5;
+        this.mfccHistoryCunters['b'] = 5;
+        this.mfccHistoryCunters['c'] = 5;
+        this.mfccHistoryCunters['d'] = 5;
+        this.mfccHistoryCunters['e'] = 5;
+        this.mfccHistoryCunters['f'] = 5;
+        this.mfccHistoryCunters['g'] = 5;
+        this.mfccHistoryCunters['h'] = 5;
+        this.mfccHistoryCunters['x'] = 5;
+        this.mfccHistoryCunters['O-O'] = 5;
+        this.mfccHistoryCunters[1] = 5;
+        this.mfccHistoryCunters[5] = 5;
+        this.mfccHistoryCunters[3] = 5;
+        this.mfccHistoryCunters[4] = 5;
+        this.mfccHistoryCunters[5] = 5;
+        this.mfccHistoryCunters[6] = 5;
+        this.mfccHistoryCunters[7] = 5;
+        this.mfccHistoryCunters[8] = 5;
+
+        return this.mfccHistoryCunters;
+    }
+}
+


### PR DESCRIPTION
Reset minimum confidence to 0.5 and added an option of adding the recognized data into the overall dataset. If the data read is equal to the data needed, we can add the new recognized data to the original dataset thus improving its accuracy for the next time that it does recognition.
The pros of the same is that we can keep training the data set while playing the game.
cons is that we would need to start with at least 50 sets of data for each of the utterances to avoid scales tipping towards the sample with higher frequency.